### PR TITLE
Make the object printing depth configurable

### DIFF
--- a/lib/concordance-options.js
+++ b/lib/concordance-options.js
@@ -1,4 +1,5 @@
 'use strict';
+const util = require('util');
 const ansiStyles = require('ansi-styles');
 const stripAnsi = require('strip-ansi');
 const cloneDeepWith = require('lodash.clonedeepwith');
@@ -124,6 +125,6 @@ const plainTheme = cloneDeepWith(colorTheme, value => {
 });
 
 const theme = chalk.enabled ? colorTheme : plainTheme;
-exports.default = {maxDepth: 3, plugins, theme};
+exports.default = {maxDepth: util.inspect.defaultOptions.depth, plugins, theme};
 exports.diff = {maxDepth: 1, plugins, theme};
 exports.snapshotManager = {plugins, theme: plainTheme};


### PR DESCRIPTION
When printing objects or exceptions, Ava restricts the depth of the printed objects to 3 levels. Some libraries that like to throw exceptions with deeply nested data in them (e.g. Axios) would benefit from increasing the printing depth when debugging failing tests, but unfortunately this depth is hardcoded in Ava and it's not possible to change it by the user.

I would propose instead to tie this depth to [`util.inspect.defaultOptions.depth`](https://nodejs.org/api/util.html#util_util_inspect_defaultoptions), which is a setting that NodeJS uses to control the depth of printing for `console.log()` and similar. Most NodeJS developers who have had to debug deeply nested objects by printing them with `console.log()` are already familiar with this setting, so it would come natural to use the same settings to control Ava's printing depth.

There are other ways this could be implemented, of course, by e.g. exposing this option as a command line argument or through some Ava-specific environment variable, but I think tying it to NodeJS's printing depth is the most practical solution. This way a NodeJS developer could kill two birds with one stone, by setting both the NodeJS and Ava printing depth in one go, rather than hunting for Ava-specific docs separately.
